### PR TITLE
Configurable optimistic GC

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -345,7 +345,7 @@ exports.makeRuntime = function(userId, onlyInRoom) {
                 runtimeChild.kill('SIGKILL');
             }
 
-            runtimeChild = child_process.fork(__dirname + '/runtime.js');
+            runtimeChild = child_process.fork(__dirname + '/runtime.js', ['--expose-gc']);
 
             console.log(`New child runtime process ${runtimeChild.pid}`);
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -292,6 +292,8 @@ process.on('message', (message) => {
         }
 
         process.send(outMessage);
+
+        if(_.isFunction(global.gc)) global.gc();
     })
     .catch((e) => {
         if(e !== false) {

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -10,7 +10,13 @@ var common = require('@screeps/common'),
     _ = require('lodash'),
     runtimeUserGlobals = require('./runtime-user-globals'),
     WorldMapGrid = require('./mapgrid'),
-    vm = require('vm');
+    vm = require('vm'),
+    v8 = require('v8');
+
+const GC_PREEMPT_THRESHOLDS = {
+    "new_space": 8*1024,
+    "code_space": 4*1024
+}
 
 var mapGrid;
 
@@ -106,6 +112,19 @@ process.on('message', (message) => {
     if(!message.userId) return;
 
     var startDirtyTime = process.hrtime();
+
+    for(let space of v8.getHeapSpaceStatistics()) {
+        let {space_name: name, space_available_size: available} = space;
+        if(name in GC_PREEMPT_THRESHOLDS && available < GC_PREEMPT_THRESHOLDS[name]) {
+            console.log(`Performing a forced GC run due to lack of available memory in ${name}: ${available}`);
+            if(!_.isFunction(global.gc)) {
+                console.error("Please run node with --expose-gc");
+                return;
+            }
+            global.gc();
+            continue;
+        }
+    };
 
     connectPromise
     .then(() => q.all([
@@ -292,8 +311,6 @@ process.on('message', (message) => {
         }
 
         process.send(outMessage);
-
-        if(_.isFunction(global.gc)) global.gc();
     })
     .catch((e) => {
         if(e !== false) {


### PR DESCRIPTION
Following up on #7, this PR allows configurable thresholds for performing GC runs prior to invoking user code.

Still requires tweaking, but from my initial local testing it has the desired effect (Running with `--trace-gc` and inspecting results). Of course, in an environment with a lot more users and more actual data, different values may be required.

The idea with this is to allow a guarantee to users that unless they allocate more than the configured values, a GC run shouldn't occur (Because it will have just done so), this without unnecessarily hurting performance at the same time.