### PR TITLE
Prevent segments from being non-strings

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -381,6 +381,9 @@ process.on('message', (message) => {
                 if(_.isNaN(key) || key < 0 || key > 99) {
                     return q.reject(`"${segmentKeys[i]}" is not a valid memory segment ID`);
                 }
+                if(typeof rawMemory.segments[segmentKeys[i]] != 'string'){
+                    return q.reject(`"${segmentKeys[i]}" is not a string`);
+                }
                 if(rawMemory.segments[segmentKeys[i]].length > 100*1024) {
                     return q.reject(`Memory segment "${segmentKeys[i]}" has exceeded 100 KB length limit`);
                 }


### PR DESCRIPTION
Segment limits can currently be bypassed by abusing an object with a toString method, this forces segments to be rejected if not a string.