### PR TITLE
Adds a timeout for user globals

### DIFF
--- a/lib/runtime/user-globals.js
+++ b/lib/runtime/user-globals.js
@@ -3,12 +3,14 @@ var vm = require('vm'),
 
 var globals = {};
 var timestamps = {};
+var timeouts = {};
 
 exports.init = function(userId, data) {
     userId = ""+userId;
 
     if(!globals[userId]) {
         globals[userId] = vm.createContext(data);
+        timeouts[userId] = Date.now() + 360000 + Math.floor(30000 * Math.random());
     }
     else {
         _.extend(globals[userId], data);
@@ -23,8 +25,9 @@ exports.get = function(userId) {
 };
 
 exports.checkObsolete = function(userId, timestamp) {
-    if(!timestamps[userId] || timestamp > timestamps[userId]) {
+    if(!timestamps[userId] || timestamp > timestamps[userId] || !timeouts[userId] || timeouts[userId] < Date.now()) {
         delete globals[userId];
+        delete timeouts[userId];
         globals[userId] = null;
     }
     timestamps[userId] = timestamp || 1;
@@ -36,4 +39,5 @@ exports.clearAll = function() {
     }
     globals = {};
     timestamps = {};
+    timeouts = {};
 };


### PR DESCRIPTION
Currently, the private server only resets globals if code is uploaded or if the global doesn't exist. This can cause performance issues on longer running servers. This PR adds timeouts to help maintain performance. The timeout is currently 6 minutes + a random addition of up to 30 seconds. The extra random time causes the resets to be spread out so all users reset at different times. 
This is a direct port from screepsmod-mongo, which has been using this since early on. 
It was originally added due to early issues on the ScreepsPlus server with runners dragging down performance.