### PR TITLE
Terminate path finding if execution times out

### DIFF
--- a/native/src/pf.cc
+++ b/native/src/pf.cc
@@ -564,6 +564,11 @@ using namespace screeps;
 				// Add next neighbors to heap
 				jps(index, pos, g_cost);
 				--ops_remaining;
+
+				// Check termination
+				if (v8::Isolate::GetCurrent()->IsExecutionTerminating()) {
+					return Nan::Undefined();
+				}
 			}
 		} catch (js_error) {
 			// Whoever threw the `js_error` should set the exception for v8


### PR DESCRIPTION
I was thinking about it and it's possible a user could misuse the path finder to raise that assertion error you were seeing. isolated-vm will wait for up to 200ms after requesting v8 to terminate the isolate before it raises that error. It seems like a pretty good amount because v8 should in theory terminate execution immediately. The path finder currently doesn't check that flag, but it should. If the user set `ops` very high while requesting an impossible path or was doing recursive path finder operations from their `roomCallback` I think they might be able to cause the error.