### PR TITLE
Fix visuals in beta

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -271,7 +271,7 @@ async function make (scope, userId, onlyInRoom) {
             for (var roomName in runResult.visual) {
                 env.setex(
                     env.keys.ROOM_VISUAL + userData.user._id + ',' + roomName + ',' + data.time,
-                    config.mainLoopResetInterval / 1000,
+                    config.engine.mainLoopResetInterval / 1000,
                     runResult.visual[roomName]);
             }
         }


### PR DESCRIPTION
Visuals in the 3.0 beta currently fail due to the expiration time being NaN, this corrects that so that visuals save properly. Thanks to @lurr in slack for helping debug and trace the issue. 

Note: As just pointed out to me in slack, visuals do not break with lokijs, likely due to its handling of expiration values, it does however, break when using screepsmod-mongo due to redis being a bit stricter