### PR TITLE
refact: Static terrain data memory optimizations

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -65,21 +65,20 @@ function getAllTerrainData() {
 
             initPathFinder(result);
 
-            staticTerrainData = {};
-            staticTerrainDataSize = 0;
-
+            staticTerrainDataSize = result.length * 2500;
             let bufferConstructor = typeof SharedArrayBuffer === 'undefined' ? ArrayBuffer : SharedArrayBuffer;
+            let view = new Uint8Array(new bufferConstructor(staticTerrainDataSize));
+            staticTerrainData = {
+                buffer: view.buffer,
+                roomOffsets: {},
+            };
 
-            result.forEach(room => {
-                var buffer = new bufferConstructor(2500);
-                var array = new Uint8Array(buffer);
-                var char;
+            result.forEach((room, roomIndex) => {
+                var offset = roomIndex * 2500;
                 for (var i = 0; i < 2500; i++) {
-                    char = room.terrain.charAt(i);
-                    array[i] = Number(char);
+                    view[i + offset] = Number(room.terrain.charAt(i));
                 }
-                staticTerrainData[room.room] = buffer;
-                staticTerrainDataSize += buffer.byteLength;
+                staticTerrainData.roomOffsets[room.room] = offset;
             });
 
             console.log('Terrain shared buffer size:', staticTerrainDataSize);

--- a/lib/runtime/runtime.js
+++ b/lib/runtime/runtime.js
@@ -17,8 +17,10 @@ global._init = (function() {
     module.exports.isolate = isolate;
     module.exports.context = context;
 
-    global._setStaticTerrainData = function (room, staticTerrainRoomData) {
-        staticTerrainData[room] = new Uint8Array(staticTerrainRoomData);
+    global._setStaticTerrainData = function (buffer, roomOffsets) {
+        for (let room in roomOffsets) {
+            staticTerrainData[room] = new Uint8Array(buffer, roomOffsets[room], 2500);
+        }
     };
 
     global._evalFn = function(fnString) {

--- a/lib/runtime/user-vm.js
+++ b/lib/runtime/user-vm.js
@@ -26,36 +26,43 @@ exports.create = async function({userId, staticTerrainData, staticTerrainDataSiz
     if(!vms[userId]) {
         let isolate = new ivm.Isolate({snapshot, memoryLimit: 256 + staticTerrainDataSize/1024/1024});
         let context = await isolate.createContext();
-        await context.global.set('global', context.global.derefInto());
-        await context.global.set('_ivm', ivm);
-        await context.global.set('_isolate', isolate);
-        await context.global.set('_context', context);
-        await context.global.set('_worldSize', index.getWorldSize());
+        let [ nativeModInstance, initScript, cleanupScript ] = await Promise.all([
+            nativeMod.create(context),
+            isolate.compileScript('_init();'),
+            isolate.compileScript('new ' + function () {
+                delete global._ivm;
+                delete global._isolate;
+                delete global._context;
+                delete global._init;
+                delete global._evalFn;
+                delete global._start;
+                delete global._setStaticTerrainData;
+                delete global._worldSize;
+                delete global._nativeMod;
+            }),
+        ]);
+        await Promise.all([
+            context.global.set('global', context.global.derefInto()),
+            context.global.set('_ivm', ivm),
+            context.global.set('_isolate', isolate),
+            context.global.set('_context', context),
+            context.global.set('_worldSize', index.getWorldSize()),
+            context.global.set('_nativeMod', nativeModInstance.derefInto()),
+            initScript.run(context),
+        ]);
+        let [ evalFn, start, setStaticTerrainData ] = await Promise.all([
+            context.global.get('_evalFn'),
+            context.global.get('_start'),
+            context.global.get('_setStaticTerrainData'),
+        ]);
 
-        let nativeModInstance = await nativeMod.create(context);
-        await context.global.set('_nativeMod', nativeModInstance.derefInto());
-
-        await (await isolate.compileScript('_init();')).run(context);
-
-        let evalFn = await context.global.get('_evalFn');
-        let start = await context.global.get('_start');
-
-        await Promise.all(Object.keys(staticTerrainData).map(async (room) => {
-            await (await context.global.get('_setStaticTerrainData')).apply(undefined,
-                [room, new ivm.ExternalCopy(staticTerrainData[room]).copyInto()]);
-        }));
-
-        await (await isolate.compileScript('new ' + function () {
-            delete global._ivm;
-            delete global._isolate;
-            delete global._context;
-            delete global._init;
-            delete global._evalFn;
-            delete global._start;
-            delete global._setStaticTerrainData;
-            delete global._worldSize;
-            delete global._nativeMod;
-        })).run(context);
+        await Promise.all([
+            setStaticTerrainData.apply(undefined, [
+                new ivm.ExternalCopy(staticTerrainData.buffer).copyInto({ release: true }),
+                new ivm.ExternalCopy(staticTerrainData.roomOffsets).copyInto({ release: true }),
+            ]),
+            cleanupScript.run(context),
+        ]);
 
         vms[userId] = {
             isolate,


### PR DESCRIPTION
This is the array buffer optimizations we discussed some time ago. A single SharedArrayBuffer (or ArrayBuffer) is created which contains the whole world's terrain in a contiguous buffer. The runtime is then responsible for slicing that up into views.

On my local server with world size 10x10 I observed a heap usage reduction of exactly 31.5kb. On shard0 I would expect each user to have an extra 3mb of heap available.

Also included are some optimizations to the isolate creation code which should result in marginally faster vm creation.