### PR TITLE
Added novice and respawn zones to runtimeData

### DIFF
--- a/lib/runtime/data.js
+++ b/lib/runtime/data.js
@@ -19,6 +19,10 @@ var bulk = require('../bulk'),
     cachedMarketOrders = {
         gameTime: 0,
         orders: {}
+    },
+    cachedZoneData = {
+        gameTime: 0,
+        zones: {}
     };
 
 function getCachedMarketOrders(gameTime) {
@@ -37,6 +41,25 @@ function getCachedMarketOrders(gameTime) {
             });
             cachedMarketOrders.orders = result;
             cachedMarketOrders.gameTime = gameTime;
+            return result;
+        });
+}
+
+function getCachedZoneData(gameTime) {
+    if(gameTime == cachedZoneData.gameTime) {
+        return q.when(cachedZoneData.zones);
+    }
+    return db.rooms.find({$or: [{novice: { $gt: Date.now()}}, {respawnArea: {$gt: Date.now()}}]})
+        .then(rooms => {
+            var result = {};
+            rooms.forEach(i => {
+                result[i._id] = {
+                    novice: i.novice,
+                    respawnArea: i.respawnArea
+                }
+            });
+            cachedZoneData.zones = result;
+            cachedZoneData.gameTime = gameTime;
             return result;
         });
 }
@@ -196,6 +219,7 @@ exports.get = function(userId, onlyInRoom) {
                 db.users.find({_id: {$in: userIds}}),
                 getCachedMarketOrders(gameTime),
                 db['market.orders'].find({user: userId}),
+                getCachedZoneData(gameTime),
                 result[0].activeSegments && result[0].activeSegments.length > 0 ?
                     env.hmget(env.keys.MEMORY_SEGMENTS+userId, result[0].activeSegments) :
                     q.when(),
@@ -215,17 +239,18 @@ exports.get = function(userId, onlyInRoom) {
                 orders: result[1],
                 myOrders: result[2]
             };
-            if(result[3]) {
+            runtimeData.zones = result[3];
+            if(result[4]) {
                 runtimeData.memorySegments = {};
                 for(var i=0; i<runtimeData.user.activeSegments.length; i++) {
                     runtimeData.memorySegments[runtimeData.user.activeSegments[i]] = result[3][i] || "";
                 }
             }
-            if(result[4] && result[4][1] && result[4][1].split(',').indexOf(""+runtimeData.user.activeForeignSegment.id) != -1) {
+            if(result[5] && result[5][1] && result[5][1].split(',').indexOf(""+runtimeData.user.activeForeignSegment.id) != -1) {
                 runtimeData.foreignMemorySegment = {
                     username: runtimeData.user.activeForeignSegment.username,
                     id: runtimeData.user.activeForeignSegment.id,
-                    data: result[4][0]
+                    data: result[5][0]
                 };
             }
             return runtimeData;


### PR DESCRIPTION
This caches the novice and respawn zone values and places them into `runtimeData` each tick. This cache is cleared once a tick, but could be setup to cache until the nearest novice/respawn zone will expire. The reason I didn't set it up this way is because I do not know the exact procedures on novice/respawn zone creation, so I do not know if they can invalidate the cache.

I have not tested this with IVM, but a quick glance through the ivm branch suggests it should work the same way, but I could be very wrong on that.

This is an attempted revision of this concept:
https://github.com/screeps/engine/pull/88

This is the PR to access these dates:
https://github.com/screeps/engine/pull/89

It's worth noting that some other files could be refactored to use this data. The primary example being the nuker structure.