### PR TITLE
Increase PathFinder maxRooms maximum to 64

### DIFF
--- a/lib/runtime/path-finder.js
+++ b/lib/runtime/path-finder.js
@@ -68,7 +68,7 @@ exports.search = function (origin, goal, options) {
     let heuristicWeight = Math.min(9, Math.max(1, options.heuristicWeight || 1));
     let maxOps = Math.max(1, (options.maxOps | 0) || 2000);
     let maxCost = Math.max(1, (options.maxCost | 0) || 0xffffffff);
-    let maxRooms = Math.min(16, Math.max(1, (options.maxRooms | 0) || 16));
+    let maxRooms = Math.min(64, Math.max(1, (options.maxRooms | 0) || 16));
     let flee = !!options.flee;
 
     // Convert one-or-many goal into standard format for native extension

--- a/native/profile.js
+++ b/native/profile.js
@@ -103,4 +103,4 @@ if (checksum !== 11843305) {
 	console.error('Incorrect results!');
 	process.exit(1);
 }
-console.log('Completed in: '+ (time[0] + time[1] / 1e9));
+console.log(time[0] + time[1] / 1e9);

--- a/native/run-pgo
+++ b/native/run-pgo
@@ -2,13 +2,28 @@
 # Runs GCC or Clang (OS X) profiling instrumentation and compiles w/ profile-guided optimizations
 set -e
 node-gyp configure
+
+rm -f build/Release/native.node
+make V=1 BUILDTYPE=Release -C build
+echo -e "\nTesting Release build now..."
+time_o3=$(node profile.js Release)
+
 make V=1 BUILDTYPE=Profile -C build
 echo -e "\nRunning instrumentation now..."
 node profile.js Profile >/dev/null
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	/usr/local/Cellar/llvm/$(brew list --versions llvm | awk '{print $2}')/bin/llvm-profdata merge -output _clangprof.profdata _clangprof.profraw
 fi
+
 make V=1 BUILDTYPE=Optimized -C build
-echo "Re-running..."
-node profile.js Optimized >/dev/null
-echo "Looks good. Replacing release with optimized."
+echo -e "\nRe-running..."
+time_optimized=$(node profile.js Optimized)
+
+if [[ $(echo "$time_o3 > $time_optimized" | bc) -eq 1 ]]; then
+	echo "Looks good. Replacing release with optimized. "
+	echo "Improvement: $(echo "scale=2; $time_o3 * 100 / $time_optimized - 100" | bc)%"
+	cp build/Optimized/native.node build/Release/native.node
+else
+	echo "Optimized build is slower! Leaving Release in place"
+	echo "Regression: $(echo "scale=2; $time_optimized * 100 / $time_o3 - 100" | bc)%"
+fi

--- a/native/src/main.cc
+++ b/native/src/main.cc
@@ -7,9 +7,9 @@
 namespace screeps {
 
 	// Init 2 Pathfinders per thread. We do 2 here because sometimes recursive calls to the path
-    // finder are useful. Any more than 2 deep recursion will have to allocate a new path finder at a
-    // cost of 471kb(!)
-    thread_local std::array<path_finder_t, 2> path_finders;
+	// finder are useful. Any more than 2 deep recursion will have to allocate a new path finder at a
+	// cost of 2.16mb(!)
+	thread_local std::array<path_finder_t, 2> path_finders;
 	uint8_t room_info_t::cost_matrix0[2500] = { 0 };
 
 	NAN_METHOD(search) {
@@ -28,8 +28,8 @@ namespace screeps {
 		}
 
 		// Get the values from v8 and run the search
-		path_finder_t::cost_t plain_cost = Nan::To<uint32_t>(info[3]).FromJust();
-		path_finder_t::cost_t swamp_cost = Nan::To<uint32_t>(info[4]).FromJust();
+		cost_t plain_cost = Nan::To<uint32_t>(info[3]).FromJust();
+		cost_t swamp_cost = Nan::To<uint32_t>(info[4]).FromJust();
 		uint8_t max_rooms = Nan::To<uint32_t>(info[5]).FromJust();
 		uint32_t max_ops = Nan::To<uint32_t>(info[6]).FromJust();
 		uint32_t max_cost = Nan::To<uint32_t>(info[7]).FromJust();

--- a/native/src/pf.h
+++ b/native/src/pf.h
@@ -8,8 +8,12 @@
 #include <vector>
 
 namespace screeps {
+	typedef uint32_t cost_t; // maximum: longest chebyshev distance of whole map
+	typedef uint32_t pos_index_t; // maximum: k_max_rooms * 2500
+	typedef uint32_t room_index_t; // maximum: k_max_rooms (32 bits tested faster than uint8_t)
+	constexpr size_t k_max_rooms = 64;
 
-	constexpr size_t k_max_rooms = 16;
+	static_assert(std::numeric_limits<pos_index_t>::max() > 2500 * k_max_rooms, "pos_index_t is too small");
 
 	//
 	// Stores coordinates of a room on the global world map.
@@ -19,7 +23,7 @@ namespace screeps {
 		union {
 			uint16_t id;
 			struct {
-				uint8_t xx, yy;
+				uint8_t xx, yy; // maximum: world_size
 			};
 		};
 
@@ -55,13 +59,20 @@ namespace screeps {
 	class world_position_t {
 
 		public:
-			uint16_t xx, yy;
+			union {
+				uint64_t id;
+				struct {
+					uint32_t xx, yy; // maximum: world_size[255] * 50 (32 bits tested faster than uint16_t)
+				};
+			};
 
 			enum direction_t { TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT, LEFT, TOP_LEFT };
 
 			world_position_t() {}
 
-			world_position_t(uint16_t xx, uint16_t yy) : xx(xx), yy(yy) {}
+			world_position_t(uint32_t xx, uint32_t yy) : xx(xx), yy(yy) {}
+
+			explicit world_position_t(uint64_t id) : id(id) {}
 
 			world_position_t(v8::Local<v8::Value> pos) {
 				v8::Local<v8::Object> obj = Nan::To<v8::Object>(pos).ToLocalChecked();
@@ -70,7 +81,7 @@ namespace screeps {
 			}
 
 			static world_position_t null() {
-				return world_position_t(0, 0);
+				return world_position_t(0);
 			}
 
 			friend std::ostream& operator<< (std::ostream& os, const world_position_t& that) {
@@ -88,11 +99,11 @@ namespace screeps {
 			}
 
 			bool operator!= (world_position_t right) const {
-				return this->xx != right.xx || this->yy != right.yy;
+				return id != right.id;
 			}
 
 			bool is_null() const {
-				return xx == 0 && yy == 0;
+				return id == 0;
 			}
 
 			world_position_t position_in_direction(direction_t dir) const {
@@ -118,8 +129,8 @@ namespace screeps {
 
 			// Gets the linear direction to a tile
 			direction_t direction_to(world_position_t pos) const {
-				int8_t dx = pos.xx - this->xx;
-				int8_t dy = pos.yy - this->yy;
+				int dx = pos.xx - this->xx;
+				int dy = pos.yy - this->yy;
 				if (dx > 0) {
 					if (dy > 0) {
 						return BOTTOM_RIGHT;
@@ -146,7 +157,7 @@ namespace screeps {
 				return (direction_t)-1;
 			}
 
-			uint16_t range_to(const world_position_t pos) const {
+			cost_t range_to(const world_position_t pos) const {
 				return std::max(
 					pos.xx > this->xx ? pos.xx - this->xx : this->xx - pos.xx,
 					pos.yy > this->yy ? pos.yy - this->yy : this->yy - pos.yy
@@ -164,14 +175,15 @@ namespace screeps {
 	class open_closed_t {
 
 		private:
-			std::array<unsigned int, capacity> list;
-			unsigned int marker;
+			using marker_t = uint32_t;
+			std::array<marker_t, capacity> list;
+			marker_t marker;
 
 		public:
 			open_closed_t() : list{}, marker(1) {}
 
 			void clear() {
-				if (std::numeric_limits<unsigned int>::max() - 2 <= marker) {
+				if (std::numeric_limits<marker_t>::max() - 2 <= marker) {
 					std::fill(list.begin(), list.end(), 0);
 					marker = 1;
 				} else {
@@ -179,19 +191,19 @@ namespace screeps {
 				}
 			}
 
-			bool is_open(unsigned int index) const {
+			bool is_open(size_t index) const {
 				return list[index] == marker;
 			}
 
-			bool is_closed(unsigned int index) const {
+			bool is_closed(size_t index) const {
 				return list[index] == marker + 1;
 			}
 
-			void open(unsigned int index) {
+			void open(size_t index) {
 				list[index] = marker;
 			}
 
-			void close(unsigned int index) {
+			void close(size_t index) {
 				list[index] = marker + 1;
 			}
 	};
@@ -217,7 +229,7 @@ namespace screeps {
 			if (cost_matrix[xx][yy]) {
 				return cost_matrix[xx][yy];
 			}
-			uint16_t index = xx * 50 + yy;
+			unsigned int index = xx * 50 + yy;
 			return 0x03 & terrain[index / 4] >> (index % 4 * 2);
 		}
 	};
@@ -225,7 +237,7 @@ namespace screeps {
 	//
 	// Stores information about a pathfinding goal, just a position + range
 	struct goal_t {
-		uint8_t range;
+		cost_t range;
 		world_position_t pos;
 		goal_t(v8::Local<v8::Value> goal) {
 			v8::Local<v8::Object> obj = Nan::To<v8::Object>(goal).ToLocalChecked();
@@ -241,8 +253,10 @@ namespace screeps {
 
 		private:
 			std::array<priority_t, capacity> priorities;
-			// This means there can only be 5000 pending nodes. It's not related to room size of 50 * 50.
-			std::array<index_t, 5000> heap;
+			// Theoretical max number of open nodes is total node divided by 8. 1 node opens all its
+			// neighbors repeated perfectly over the whole graph. It's impossible to actually hit this
+			// limit with a regular pathfinder operation
+			std::array<index_t, 2500 * k_max_rooms / 8> heap;
 			size_t size_;
 
 		public:
@@ -323,11 +337,6 @@ namespace screeps {
 	//
 	// Path finder encapsulation. Multiple instances are thread-safe
 	class path_finder_t {
-		public:
-			typedef uint32_t cost_t;
-			typedef uint16_t pos_index_t;
-			typedef uint8_t room_index_t;
-
 		private:
 			static constexpr size_t map_position_size = 1 << sizeof(map_position_t) * 8;
 			std::array<room_info_t, k_max_rooms> room_table;
@@ -341,7 +350,7 @@ namespace screeps {
 			cost_t plain_cost;
 			cost_t swamp_cost;
 			double heuristic_weight;
-			uint8_t max_rooms;
+			room_index_t max_rooms;
 			bool flee;
 			v8::Local<v8::Value>* room_data_handles;
 			v8::Local<v8::Function>* room_callback;


### PR DESCRIPTION
Some users have said that increasing this limit would be useful to them. Since any time the pathfinder enters a room it counts against maxRooms, you usually end up with a maximum path shorter than 16 rooms long.

With the existing code the highest we could bump the k_max_rooms constant to was 24, so I went through and audited and updated the data structures in use. This increases memory usage a little, but reduces CPU overhead a little bit too **(by about 7%)**. The pathfinder is *almost* allocation-free which means that it allocates all the memory it could possibly need upfront and holds on to it for the program's lifetime. The old code would use ~49kb of memory per thread per k_max_rooms, plus about 74kb of other overhead. The new code uses ~84kb of memory per thread per k_max_rooms, plus the same overhead.

Assuming a 4 thread server, before this patch the pathfinder will hold onto ~3.63mb of memory. After this patch it will hold onto 17.27mb of memory. I don't think that number is unreasonable by any measure but I did want to make sure to communicate the exact cost of this change. And like I mentioned it is 7% faster, at least on my system and probably most 64-bit systems.

This also includes the fix for the "Max heap" issue we discussed a couple days ago. It'll automatically adjust the heap size to the correct capacity based on k_max_rooms.