### PR TITLE
Run some promises in parallel, wait for all promises

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -95,25 +95,29 @@ function getUserData(userId) {
                 cpu = user.cpuAvailable || 0;
                 if(user.skipTicksPenalty > 0) {
                     console.log(`Skip user execution ${user.username} (penalty ${user.skipTicksPenalty})`);
-                    db.users.update({_id: user._id}, {$set: {
+                    return db.users.update({_id: user._id}, {$set: {
                         lastUsedCpu: 0,
                         lastUsedDirtyTime: 0
-                    }, $inc: {skipTicksPenalty: -1}});
-                    return q.reject({
-                        type: 'error',
-                        error: 'Your script is temporary blocked due to a hard reset inflicted to the runtime process.\nPlease try to change your code in order to prevent causing hard timeout resets.'
+                    }, $inc: {skipTicksPenalty: -1}})
+                    .then(() => {
+                      return q.reject({
+                          type: 'error',
+                          error: 'Your script is temporary blocked due to a hard reset inflicted to the runtime process.\nPlease try to change your code in order to prevent causing hard timeout resets.'
+                      })
                     });
                 }
                 if(user.cpuAvailable < 0) {
                     console.log(`Skip user execution ${user.username} (${user.cpuAvailable})`);
-                    db.users.update({_id: user._id}, {$set: {
+                    return db.users.update({_id: user._id}, {$set: {
                         lastUsedCpu: 0,
                         lastUsedDirtyTime: 0,
                         cpuAvailable: user.cpuAvailable < -user.cpu * 2 ? -user.cpu * 2 : user.cpuAvailable + user.cpu
-                    }});
-                    return q.reject({
-                        type: 'error',
-                        error: 'Script execution has been terminated: CPU bucket is empty'
+                    }})
+                    .then(() => {
+                      return q.reject({
+                          type: 'error',
+                          error: 'Script execution has been terminated: CPU bucket is empty'
+                      });
                     });
                 }
                 cpu += user.cpu;
@@ -132,17 +136,17 @@ function getUserData(userId) {
 
 async function make (scope, userId, onlyInRoom) {
 
-    let userData;
+    let userData, data;
 
     try {
 
-        await getAllTerrainData();
+        let [, _userData, _data] = await Promise.all([
+          getAllTerrainData(),
+          getUserData(userId),
+          runtimeData.get(userId, onlyInRoom)]);
 
-        if(scope.abort) {
-            throw 'aborted';
-        }
-
-        userData = await getUserData(userId);
+        userData = _userData;
+        data = _data;
 
         if(scope.abort) {
             throw 'aborted';
@@ -161,7 +165,6 @@ async function make (scope, userId, onlyInRoom) {
 
     try {
 
-        let data = await runtimeData.get(userId, onlyInRoom);
         let dataRef = new ivm.ExternalCopy(data);
 
         if(scope.abort) {
@@ -209,6 +212,8 @@ async function make (scope, userId, onlyInRoom) {
         run.dispose();
         dataRef.dispose();
 
+        let promises = [];
+
         var $set = {
             lastUsedCpu: runResult.usedTime,
             lastUsedDirtyTime: runResult.usedDirtyTime
@@ -227,26 +232,26 @@ async function make (scope, userId, onlyInRoom) {
             $set.cpuAvailable = newCpuAvailable;
         }
 
-        db.users.update({_id: userData.user._id}, {$set});
+        promises.push(db.users.update({_id: userData.user._id}, {$set}));
 
         if (runResult.activeForeignSegment !== undefined) {
             if (runResult.activeForeignSegment === null) {
-                db.users.update({_id: userData.user._id}, {
+                promises.push(db.users.update({_id: userData.user._id}, {
                     $unset: {
                         activeForeignSegment: true
                     }
-                });
+                }));
             }
             else {
                 if (userData.user.activeForeignSegment &&
                     runResult.activeForeignSegment.username == userData.user.activeForeignSegment.username &&
                     runResult.activeForeignSegment.id) {
-                    db.users.update({_id: userData.user._id}, {$merge: {
+                    promises.push(db.users.update({_id: userData.user._id}, {$merge: {
                         activeForeignSegment: {id: runResult.activeForeignSegment.id}
-                    }});
+                    }}));
                 }
                 else {
-                    db.users.findOne({username: runResult.activeForeignSegment.username}, {defaultPublicSegment: true})
+                    promises.push(db.users.findOne({username: runResult.activeForeignSegment.username}, {defaultPublicSegment: true})
                         .then(user => {
                             runResult.activeForeignSegment.user_id = user._id;
                             if(!runResult.activeForeignSegment.id && user.defaultPublicSegment) {
@@ -254,10 +259,10 @@ async function make (scope, userId, onlyInRoom) {
                             }
                         })
                         .finally(() => {
-                            db.users.update({_id: userData.user._id}, {$set: {
+                            return db.users.update({_id: userData.user._id}, {$set: {
                                 activeForeignSegment: runResult.activeForeignSegment
                             }});
-                        })
+                        }))
                 }
             }
         }
@@ -274,6 +279,8 @@ async function make (scope, userId, onlyInRoom) {
                     runResult.visual[roomName]);
             }
         }
+
+        await Promise.all(promises);
 
         if (/CPU limit reached/.test(runResult.error)) {
             pubsub.publish(`user:${userData.user._id}/cpu`, JSON.stringify({


### PR DESCRIPTION
Waiting for getAllTerrainData(), getUserData() and runtimeData.get all at once is giving me a decent speedup. Before it was about 600-900ms per tick when the server starts up, with this change it is 400-500ms.

Also, some promises were not being waited for. It doesn't look like anything actually used them right after, so that probably never caused any issues, but this way should be a bit safer.