### PR TITLE
Check pathfinder module validity

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -48,6 +48,9 @@ function initPathFinder(rooms) {
         });
     });
 
+    if (native.version !== 10) {
+        throw new Error('Invalid pathfinder binary');
+    }
     native.loadTerrain(terrainData);
 }
 

--- a/native/src/main.cc
+++ b/native/src/main.cc
@@ -53,6 +53,7 @@ namespace screeps {
 extern "C" IVM_DLLEXPORT void InitForContext(v8::Isolate* isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> target) {
 	Nan::Set(target, Nan::New("search").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(screeps::search)).ToLocalChecked());
 	Nan::Set(target, Nan::New("loadTerrain").ToLocalChecked(), Nan::GetFunction(Nan::New<v8::FunctionTemplate>(screeps::load_terrain)).ToLocalChecked());
+	Nan::Set(target, Nan::New("version").ToLocalChecked(), Nan::New<v8::Number>(10));
 }
 
 NAN_MODULE_INIT(init) {


### PR DESCRIPTION
This saves a version identifier on the pathfinder module and will refuse to run if it doesn't match the expected value.