### PR TITLE
Calculate CPU usage outside of the player's isolate.

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -92,6 +92,27 @@ function getUserData(userId) {
         });
 }
 
+function countIntents(intents) {
+    return _(intents).map((subintents, subname) => {
+        if(subname === 'notify') {
+            return subintents.length;
+        }
+        if(!_.isObject(subintents)) return 0;
+        if(subname === 'global') {
+            return _(subintents).map(intentList => intentList.length || 0).sum();
+        }
+        return _(subintents).map((objIntents, id) => {
+            if(id === 'room') {
+                return _(subintents).map(objIntents => objIntents.length || 0).sum();
+            }
+            return _(objIntents).map((intent, name) => {
+                if(name === 'pull' || name === 'say' || !_.isObject(intent)) return 0;
+                return 1;
+            });
+        })
+    }).sum();
+}
+
 async function make (scope, userId, onlyInRoom) {
 
     let userData;
@@ -139,6 +160,7 @@ async function make (scope, userId, onlyInRoom) {
 
         let vm = runtimeUserVm.get(userId);
 
+        const startDirtyTime = vm.isolate.nowCpuTime();
         let run = await vm.start.apply(undefined, [dataRef.copyInto()]);
 
         if(scope.abort) {
@@ -166,14 +188,20 @@ async function make (scope, userId, onlyInRoom) {
             }
         }, userId);
 
+        const starUsedTime = vm.isolate.nowCpuTime();
         runResult = await run.apply(undefined, [], {timeout: data.timeout});
+        const endCpuTime = vm.isolate.nowCpuTime();
 
         run.dispose();
         dataRef.dispose();
 
+        let intentCount = countIntents(runResult.intents);
+        runResult.intentsCpu = intentCount / 0.2;
+        const usedTime = Math.ceil((endCpuTime - starUsedTime) + runResult.intentsCpu);
+
         var $set = {
-            lastUsedCpu: runResult.usedTime,
-            lastUsedDirtyTime: runResult.usedDirtyTime
+            lastUsedCpu: usedTime,
+            lastUsedDirtyTime: Math.ceil(endCpuTime - startDirtyTime),
         };
         if (runResult.activeSegments) {
             $set.activeSegments = runResult.activeSegments;
@@ -182,7 +210,7 @@ async function make (scope, userId, onlyInRoom) {
             $set.defaultPublicSegment = runResult.defaultPublicSegment;
         }
         if (userData.cpu < Infinity) {
-            var newCpuAvailable = userData.user.cpuAvailable + userData.user.cpu - runResult.usedTime;
+            var newCpuAvailable = userData.user.cpuAvailable + userData.user.cpu - usedTime;
             if(newCpuAvailable > config.engine.cpuBucketSize) {
                 newCpuAvailable = config.engine.cpuBucketSize;
             }

--- a/lib/runtime/runtime.js
+++ b/lib/runtime/runtime.js
@@ -11,9 +11,7 @@ global._init = (function() {
     const cpuHalt = _halt;
     let mapGrid, staticTerrainData = {}, scope;
 
-    function nowCpuTime() {
-        return isolate.cpuTime[0] * 1e3 + isolate.cpuTime[1] / 1e6;
-    }
+    const nowCpuTime = isolate.nowCpuTime;
 
     module.exports.isolate = isolate;
     module.exports.context = context;
@@ -31,7 +29,7 @@ global._init = (function() {
     global._start = function (data) {
 
         let activeSegments, publicSegments, defaultPublicSegment, activeForeignSegment;
-        let startTime, startDirtyTime = nowCpuTime();
+        let startTime = nowCpuTime();
         let intentCpu = 0.2,
             freeMethods = {say: true, pull: true};
 
@@ -241,10 +239,7 @@ global._init = (function() {
                 }
             }
 
-            outMessage.usedTime = Math.ceil(nowCpuTime() - startTime + intents.cpu);
-            outMessage.usedDirtyTime = Math.ceil(nowCpuTime() - startDirtyTime);
             outMessage.intents = utils.storeIntents(data.user._id, intents.list, data);
-            outMessage.intentsCpu = intents.cpu;
             outMessage.memory = data.userMemory;
             outMessage.console = {
                 log: fakeConsole.getMessages(data.user._id),

--- a/lib/runtime/user-vm.js
+++ b/lib/runtime/user-vm.js
@@ -28,6 +28,10 @@ exports.create = async function({userId, staticTerrainData, staticTerrainDataSiz
     if(!vms[userId]) {
         let inspector = config.engine.enableInspector;
         let isolate = new ivm.Isolate({inspector, snapshot, memoryLimit: 256 + staticTerrainDataSize/1024/1024});
+        isolate.nowCpuTime = function() {
+            const time = this.cpuTime;
+            return time[0] * 1e3 + time[1] / 1e6;
+        }
         let vm = vms[userId] = {isolate, ready: false};
         vm.promise = async function() {
             let context = await isolate.createContext({inspector});


### PR DESCRIPTION
This moves cpu usage tracking outside of the player's isolate. Within the isolate it's possible for a player to alter the calculation in their favor.