### PR TITLE
Allow ArrayBuffer to be stored in RawMemory

### DIFF
--- a/lib/runtime/runtime.js
+++ b/lib/runtime/runtime.js
@@ -81,10 +81,15 @@ global._init = (function() {
             },
             set: {
                 value: function (value) {
-                    if (!_.isString(value)) {
-                        throw new Error('Raw memory value is not a string');
+                    let length = Infinity;
+                    if(value instanceof ArrayBuffer && Object.prototype.toString.call(value) === '[object ArrayBuffer]'){
+                        length = value.byteLength;
+                    }else if (_.isString(value)) {
+                        length = value.length;
+                    }else{
+                        throw new Error('Raw memory value is not a string or ArrayBuffer');
                     }
-                    if (value.length > 2 * 1024 * 1024) {
+                    if (length > 2 * 1024 * 1024) {
                         throw new Error('Raw memory length exceeded 2 MB limit');
                     }
                     if (this._parsed) {


### PR DESCRIPTION
ArrayBuffer can be passed through IVM. Allowing ArrayBuffer in RawMemory gives user more control over their memory.