### PR TITLE
Support newer version of isolated-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "dependencies": {
     "generic-pool": "^3.4.1",
-    "isolated-vm": "^2.0.1",
+    "isolated-vm": "^3.0.0",
     "lodash": "^3.10.1",
     "nan": "^2.14.0",
     "node-gyp": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@screeps/driver",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "",
   "main": "lib/index.js",
   "author": "Artem Chivchalov <contact@screeps.com>",


### PR DESCRIPTION
The isolated-vm blocking the compiles with latest visual studio.
The only way to compile it, is to use version 3.0 of isolated-vm.
This pull request Fixes #43  