### PR TITLE
Fixes to allow setting zero as activeForeignSegment

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -202,7 +202,7 @@ async function make (scope, userId) {
             else {
                 if (userData.user.activeForeignSegment &&
                     runResult.activeForeignSegment.username == userData.user.activeForeignSegment.username &&
-                    runResult.activeForeignSegment.id) {
+                    typeof runResult.activeForeignSegment.id === "number") {
                     db.users.update({_id: userData.user._id}, {$merge: {
                         activeForeignSegment: {id: runResult.activeForeignSegment.id}
                     }});
@@ -211,7 +211,7 @@ async function make (scope, userId) {
                     db.users.findOne({username: runResult.activeForeignSegment.username}, {defaultPublicSegment: true})
                         .then(user => {
                             runResult.activeForeignSegment.user_id = user._id;
-                            if(!runResult.activeForeignSegment.id && user.defaultPublicSegment) {
+                            if(typeof runResult.activeForeignSegment.id !== "number" && typeof user.defaultPublicSegment === "number") {
                                 runResult.activeForeignSegment.id = user.defaultPublicSegment;
                             }
                         })


### PR DESCRIPTION
Replaced two conditionals with a check for a number since zero is a valid value.

https://docs.screeps.com/api/#RawMemory.setActiveForeignSegment
The ID of the memory segment from 0 to 99.