### PR TITLE
pf.h: #include <limits> (for std::numeric_limits) for gcc 11+

### DIFF
--- a/native/src/pf.h
+++ b/native/src/pf.h
@@ -2,6 +2,7 @@
 #include <nan.h>
 #include <array>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <unordered_set>


### PR DESCRIPTION
With gcc 11 as part of more recent Linux distros, some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.

The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 11:

<limits> (for std::numeric_limits)

Addresses: https://github.com/screeps/driver/issues/47
Reference: https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes