### PR TITLE
Require `he` so it can be used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var bulk = require('./bulk'),
     runtimeUserVm = require('./runtime/user-vm'),
     roomStatsUpdates = {},
     genericPool = require('generic-pool'),
+    he = require('he'),
     worldSize;
 
 _.extend(config.engine, {


### PR DESCRIPTION
This fixes the following error:
```
[engine_runner1] Error in runner loop: ReferenceError: he is not defined
    at messages.log.messages.log.map.item (/screeps/node_modules/@screeps/driver/lib/index.js:366:59)
    at Array.map (<anonymous>)
    at Object.exports.sendConsoleMessages (/screeps/node_modules/@screeps/driver/lib/index.js:366:33)
    at saveResult (/screeps/node_modules/@screeps/engine/dist/runner.js:25:20)
```
reproduced from Jomik's server and the vanilla one, using the following "bot":
```js
module.exports.loop = () => {
    console.log("Tick");
}
```