### PR TITLE
Expose the shard name and remaining bucket in the `user:$id/cpu` message

### DIFF
--- a/lib/runtime/make.js
+++ b/lib/runtime/make.js
@@ -13,7 +13,8 @@ var common = require('@screeps/common'),
     pathfinderFactory = require('../path-finder'),
     index = require('../index'),
     runtimeData = require('./data'),
-    runtimeUserVm = require('./user-vm');
+    runtimeUserVm = require('./user-vm'),
+    os = require('os');
 
 let staticTerrainData, staticTerrainDataSize = 0;
 
@@ -211,6 +212,7 @@ async function make (scope, userId) {
             $set.cpuAvailable = newCpuAvailable;
         }
 
+        Object.assign(userData.user, $set);
         db.users.update({_id: userData.user._id}, {$set});
 
         if (runResult.activeForeignSegment !== undefined) {
@@ -259,15 +261,20 @@ async function make (scope, userId) {
             }
         }
 
+        const shardName = await env.get(env.keys.SHARD_NAME) ?? os.hostname();
         if (/CPU limit reached/.test(runResult.error)) {
             pubsub.publish(`user:${userData.user._id}/cpu`, JSON.stringify({
+                shard: shardName,
                 cpu: 'error',
+                bucket: userData.user.cpuAvailable,
                 memory: runResult.memory.data.length
             }));
         }
         else {
             pubsub.publish(`user:${userData.user._id}/cpu`, JSON.stringify({
+                shard: shardName,
                 cpu: runResult.usedTime,
+                bucket: userData.user.cpuAvailable,
                 memory: runResult.memory.data.length
             }));
         }


### PR DESCRIPTION
The idea is that this lets the client know (for MMO) which shard the received message belongs to, possibly letting it filter out the one that correspond to the currently viewed shard instead of being random.

`bucket` is just there because some people thought having the bucket in the UI would also be nice.

Caveat: this is assuming a lot about how MMO handles its sharding, which is private code; so the current way is based on what driver [does](https://github.com/screeps/driver/blob/master/lib/index.js#L38), with a previous get for the value `screepsmod-admin-utils` uses.

Discord Issue: https://discord.com/channels/860665589738635336/1493610087334547497